### PR TITLE
Split Dockerfile to runtime and devel version

### DIFF
--- a/build_docker_images.sh
+++ b/build_docker_images.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+docker build -t gemfield/zlmediakit:20.01-runtime-ubuntu18.04 -f docker/ubuntu18.04/Dockerfile.runtime .
+#docker build -t gemfield/zlmediakit:20.01-devel-ubuntu18.04 -f docker/ubuntu18.04/Dockerfile.devel .

--- a/docker/ubuntu16.04/Dockerfile.devel
+++ b/docker/ubuntu16.04/Dockerfile.devel
@@ -1,0 +1,43 @@
+FROM ubuntu:16.04
+#shell,rtmp,rtsp,rtsps,http,https,rtp
+EXPOSE 9000/tcp
+EXPOSE 1935/tcp
+EXPOSE 554/tcp
+EXPOSE 322/tcp
+EXPOSE 80/tcp
+EXPOSE 443/tcp
+EXPOSE 10000/udp
+EXPOSE 10000/tcp
+
+RUN apt-get update && \
+         DEBIAN_FRONTEND="noninteractive" \
+         apt-get install -y --no-install-recommends \
+         build-essential \
+         cmake \
+         git \
+         curl \
+         vim \
+         ca-certificates \
+         tzdata \
+         libssl-dev \
+         libmysqlclient-dev \
+         libx264-dev \
+         libfaac-dev \
+         libmp4v2-dev && \
+         apt autoremove -y && \
+         apt clean -y && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /opt/media
+
+WORKDIR /opt/media
+RUN git clone --depth=1 https://github.com/xiongziliang/ZLMediaKit && \
+    cd ZLMediaKit && git submodule update --init --recursive && \
+    mkdir -p build release/linux/Release/
+
+WORKDIR /opt/media/ZLMediaKit/build
+RUN cmake -DCMAKE_BUILD_TYPE=Release .. && \
+    make -j4
+
+ENV PATH /opt/media/ZLMediaKit/release/linux/Release/:$PATH
+CMD MediaServer

--- a/docker/ubuntu16.04/Dockerfile.runtime
+++ b/docker/ubuntu16.04/Dockerfile.runtime
@@ -1,0 +1,62 @@
+FROM ubuntu:16.04 AS build
+#shell,rtmp,rtsp,rtsps,http,https,rtp
+EXPOSE 9000/tcp
+EXPOSE 1935/tcp
+EXPOSE 554/tcp
+EXPOSE 322/tcp
+EXPOSE 80/tcp
+EXPOSE 443/tcp
+EXPOSE 10000/udp
+EXPOSE 10000/tcp
+
+RUN apt-get update && \
+         DEBIAN_FRONTEND="noninteractive" \
+         apt-get install -y --no-install-recommends \
+         build-essential \
+         cmake \
+         git \
+         curl \
+         vim \
+         ca-certificates \
+         tzdata \
+         libssl-dev \
+         libmysqlclient-dev \
+         libx264-dev \
+         libfaac-dev \
+         libmp4v2-dev && \
+         apt autoremove -y && \
+         apt clean -y && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /opt/media
+
+WORKDIR /opt/media
+RUN git clone --depth=1 https://github.com/xiongziliang/ZLMediaKit && \
+    cd ZLMediaKit && git submodule update --init --recursive && \
+    mkdir -p build release/linux/Release/
+
+WORKDIR /opt/media/ZLMediaKit/build
+RUN cmake -DCMAKE_BUILD_TYPE=Release .. && \
+    make -j4
+
+FROM ubuntu:16.04
+LABEL maintainer "Gemfield <gemfield@civilnet.cn>"
+
+RUN apt-get update && \
+         DEBIAN_FRONTEND="noninteractive" \
+         apt-get install -y --no-install-recommends \
+         vim \
+         ca-certificates \
+         tzdata \
+         libssl-dev \
+         libx264-dev \
+         libfaac-dev \
+         libmp4v2-dev && \
+         apt autoremove -y && \
+         apt clean -y && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /opt/media/bin/
+COPY --from=build /opt/media/ZLMediaKit/release/linux/Release/MediaServer /opt/media/bin/MediaServer
+ENV PATH /opt/media/bin:$PATH
+CMD MediaServer

--- a/docker/ubuntu18.04/Dockerfile.devel
+++ b/docker/ubuntu18.04/Dockerfile.devel
@@ -1,4 +1,5 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
+LABEL maintainer "Gemfield <gemfield@civilnet.cn>"
 #shell,rtmp,rtsp,rtsps,http,https,rtp
 EXPOSE 9000/tcp
 EXPOSE 1935/tcp
@@ -9,7 +10,9 @@ EXPOSE 443/tcp
 EXPOSE 10000/udp
 EXPOSE 10000/tcp
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && \
+         DEBIAN_FRONTEND="noninteractive" \
+         apt-get install -y --no-install-recommends \
          build-essential \
          cmake \
          git \
@@ -22,6 +25,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
          libx264-dev \
          libfaac-dev \
          libmp4v2-dev && \
+         apt autoremove -y && \
+         apt clean -y && \
     rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /opt/media
@@ -35,6 +40,5 @@ WORKDIR /opt/media/ZLMediaKit/build
 RUN cmake -DCMAKE_BUILD_TYPE=Release .. && \
     make -j4
 
-ENV PATH /opt/media/ZLMediaKit/release/linux/Release/:$PATH
-
+ENV PATH /opt/media/ZLMediaKit/release/linux/Release:$PATH
 CMD MediaServer

--- a/docker/ubuntu18.04/Dockerfile.runtime
+++ b/docker/ubuntu18.04/Dockerfile.runtime
@@ -1,0 +1,62 @@
+FROM ubuntu:18.04 AS build
+#shell,rtmp,rtsp,rtsps,http,https,rtp
+EXPOSE 9000/tcp
+EXPOSE 1935/tcp
+EXPOSE 554/tcp
+EXPOSE 322/tcp
+EXPOSE 80/tcp
+EXPOSE 443/tcp
+EXPOSE 10000/udp
+EXPOSE 10000/tcp
+
+RUN apt-get update && \
+         DEBIAN_FRONTEND="noninteractive" \
+         apt-get install -y --no-install-recommends \
+         build-essential \
+         cmake \
+         git \
+         curl \
+         vim \
+         ca-certificates \
+         tzdata \
+         libssl-dev \
+         libmysqlclient-dev \
+         libx264-dev \
+         libfaac-dev \
+         libmp4v2-dev && \
+         apt autoremove -y && \
+         apt clean -y && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /opt/media
+
+WORKDIR /opt/media
+RUN git clone --depth=1 https://github.com/xiongziliang/ZLMediaKit && \
+    cd ZLMediaKit && git submodule update --init --recursive && \
+    mkdir -p build release/linux/Release/
+
+WORKDIR /opt/media/ZLMediaKit/build
+RUN cmake -DCMAKE_BUILD_TYPE=Release .. && \
+    make -j4
+
+FROM ubuntu:18.04
+LABEL maintainer "Gemfield <gemfield@civilnet.cn>"
+
+RUN apt-get update && \
+         DEBIAN_FRONTEND="noninteractive" \
+         apt-get install -y --no-install-recommends \
+         vim \
+         ca-certificates \
+         tzdata \
+         libssl-dev \
+         libx264-dev \
+         libfaac-dev \
+         libmp4v2-dev && \
+         apt autoremove -y && \
+         apt clean -y && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /opt/media/bin/
+COPY --from=build /opt/media/ZLMediaKit/release/linux/Release/MediaServer /opt/media/bin/MediaServer
+ENV PATH /opt/media/bin:$PATH
+CMD MediaServer


### PR DESCRIPTION
1. Split Dockerfile to runtime and devel version;
2. Reduce the image size for runtime version.