### PR TITLE
改进了getSnap操作的问题

### DIFF
--- a/server/Process.cpp
+++ b/server/Process.cpp
@@ -165,10 +165,10 @@ static void s_kill(pid_t pid,int max_delay,bool force){
         WarnL << "\nOpen Process fAiled: " << GetLastError();
         return;
     }
-    DWORD ret = TerminateProcess(hProcess, 0);	//结束目标进程
-    if (ret == 0) {
-        WarnL << GetLastError;
-    }
+    //DWORD ret = TerminateProcess(hProcess, 0);	//结束目标进程
+    //if (ret == 0) {
+    //    WarnL << GetLastError;
+    //}
 #else
     if (::kill(pid, force ? SIGKILL : SIGTERM) == -1) {
         //进程可能已经退出了


### PR DESCRIPTION
1、Process.cpp中修正了windows运行getSnap时被过早关闭的问题；
2、在WebApi.cpp中的getSnap API处理中，启动ffmpeg进程后，监视生成的文件，在相隔0.5秒文件大小不变时视为截图文件正常生成，然后向请求方返回结果。