### PR TITLE
子模块地址使用相对路径

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "ZLToolKit"]
 	path = 3rdpart/ZLToolKit
-	url = https://gitee.com/xiahcu/ZLToolKit
+	url = ../ZLToolKit
 [submodule "3rdpart/media-server"]
 	path = 3rdpart/media-server
-	url = https://gitee.com/xiahcu/media-server
+	url = ../media-server


### PR DESCRIPTION
子模块地址使用相对路径。
* 统一服务器，即主库通过 github 下载则子库也通过 github 下载；
* 也方便做 git 镜像，在自建 git 服务器上镜像后访问也更方便；